### PR TITLE
Letting axrat be free for a non-circular bulge in 2 comp mode

### DIFF
--- a/R/profuseSingleImage.R
+++ b/R/profuseSingleImage.R
@@ -298,7 +298,7 @@ profuseFound2Fit = function(image,
         re = mini_profound$segstats[loc_tar, 'R50'] * c(0.5, 1.5),
         nser = c(bulge_nser, disk_nser),
         ang = c(ifelse(bulge_circ, 0, mini_profound$segstats[loc_tar, 'ang']), mini_profound$segstats[loc_tar, 'ang']),
-        axrat = c(1, mini_profound$segstats[loc_tar, 'axrat'])
+        axrat = c(ifelse(bulge_circ, 1, mini_profound$segstats[loc_tar, 'axrat']), mini_profound$segstats[loc_tar, 'axrat'])
       )
     )
   } else if (Ncomp == 1.5) {
@@ -327,7 +327,7 @@ profuseFound2Fit = function(image,
         re = mini_profound$segstats[loc_tar, 'R50'] * c(0.5, 2, 1),
         nser = c(bulge_nser, disk_nser, disk_nser),
         ang = c(ifelse(bulge_circ, 0, mini_profound$segstats[loc_tar, 'ang']), rep(mini_profound$segstats[loc_tar, 'ang'],2)),
-        axrat = c(1, rep(mini_profound$segstats[loc_tar, 'axrat'],2))
+        axrat = c(ifelse(bulge_circ, 1, mini_profound$segstats[loc_tar, 'axrat']), rep(mini_profound$segstats[loc_tar, 'axrat'],2))
       )
     )
   }


### PR DESCRIPTION
Setting the initial guess for axrat to be free in Ncomp=2 mode, when BulgeCirc=FALSE